### PR TITLE
Fixed typo in language reference

### DIFF
--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -674,7 +674,7 @@ themes <themeUrl> [themeUrl] ... [themeUrl]
 
 ### branding
 
-The ```branding``` keyword allows you to define some custom branding that should be usedwhen rendering diagrams and documentation. See [Structurizr - Branding](https://structurizr.com/help/branding) for more details.
+The ```branding``` keyword allows you to define some custom branding that should be used when rendering diagrams and documentation. See [Structurizr - Branding](https://structurizr.com/help/branding) for more details.
 
 ```
 branding {


### PR DESCRIPTION
The PR fixes a small typo in _Language reference_ documentation.