### PR TITLE
Add interpretation for marking software systems and persons as external when using an enterprise

### DIFF
--- a/src/main/java/com/structurizr/dsl/PersonParser.java
+++ b/src/main/java/com/structurizr/dsl/PersonParser.java
@@ -1,6 +1,7 @@
 package com.structurizr.dsl;
 
 import com.structurizr.model.Location;
+import com.structurizr.model.Model;
 import com.structurizr.model.Person;
 
 final class PersonParser extends AbstractParser {
@@ -23,15 +24,17 @@ final class PersonParser extends AbstractParser {
             description = tokens.get(DESCRIPTION_INDEX);
         }
 
-        Person person = context.getWorkspace().getModel().addPerson(name, description);
+        Person person = getModel(context).addPerson(name, description);
 
         if (tokens.includes(TAGS_INDEX)) {
             String tags = tokens.get(TAGS_INDEX);
             person.addTags(tags.split(","));
         }
 
-        if (context instanceof EnterpriseDslContext) {
+        if (isInsideEnterpriseContext(context)) {
             person.setLocation(Location.Internal);
+        } else if (isOutSideOfEnterpriseContext(context)) {
+            person.setLocation(Location.External);
         }
 
         if (context.hasGroup()) {
@@ -39,6 +42,18 @@ final class PersonParser extends AbstractParser {
         }
 
         return person;
+    }
+
+    private boolean isInsideEnterpriseContext(GroupableDslContext context) {
+        return context instanceof EnterpriseDslContext;
+    }
+
+    private boolean isOutSideOfEnterpriseContext(GroupableDslContext context) {
+        return !isInsideEnterpriseContext(context) && getModel(context).getEnterprise() != null;
+    }
+
+    private Model getModel(GroupableDslContext context) {
+        return context.getWorkspace().getModel();
     }
 
 }

--- a/src/main/java/com/structurizr/dsl/SoftwareSystemParser.java
+++ b/src/main/java/com/structurizr/dsl/SoftwareSystemParser.java
@@ -1,6 +1,7 @@
 package com.structurizr.dsl;
 
 import com.structurizr.model.Location;
+import com.structurizr.model.Model;
 import com.structurizr.model.SoftwareSystem;
 
 final class SoftwareSystemParser extends AbstractParser {
@@ -30,8 +31,10 @@ final class SoftwareSystemParser extends AbstractParser {
             softwareSystem.addTags(tags.split(","));
         }
 
-        if (context instanceof EnterpriseDslContext) {
+        if (isInsideEnterpriseContext(context)) {
             softwareSystem.setLocation(Location.Internal);
+        } else if (isOutSideOfEnterpriseContext(context)) {
+            softwareSystem.setLocation(Location.External);
         }
 
         if (context.hasGroup()) {
@@ -40,5 +43,18 @@ final class SoftwareSystemParser extends AbstractParser {
 
         return softwareSystem;
     }
+
+    private boolean isInsideEnterpriseContext(GroupableDslContext context) {
+        return context instanceof EnterpriseDslContext;
+    }
+
+    private boolean isOutSideOfEnterpriseContext(GroupableDslContext context) {
+        return !isInsideEnterpriseContext(context) && getModel(context).getEnterprise() != null;
+    }
+
+    private Model getModel(GroupableDslContext context) {
+        return context.getWorkspace().getModel();
+    }
+
 
 }

--- a/src/test/java/com/structurizr/dsl/PersonParserTests.java
+++ b/src/test/java/com/structurizr/dsl/PersonParserTests.java
@@ -1,5 +1,6 @@
 package com.structurizr.dsl;
 
+import com.structurizr.model.Enterprise;
 import com.structurizr.model.Location;
 import com.structurizr.model.Person;
 import org.junit.jupiter.api.Test;
@@ -67,6 +68,21 @@ class PersonParserTests extends AbstractTests {
         assertNotNull(user);
         assertEquals("", user.getDescription());
         assertEquals(Location.Internal, user.getLocation());
+        assertEquals("Element,Person", user.getTags());
+    }
+
+    @Test
+    void test_parse_CreatesAnExternalPerson() {
+        ModelDslContext context = context();
+        context.getWorkspace().getModel().setEnterprise(new Enterprise("Example Enterprise"));
+
+        parser.parse(context, tokens("person", "User"));
+
+        assertEquals(1, model.getElements().size());
+        Person user = model.getPersonWithName("User");
+        assertNotNull(user);
+        assertEquals("", user.getDescription());
+        assertEquals(Location.External, user.getLocation());
         assertEquals("Element,Person", user.getTags());
     }
 

--- a/src/test/java/com/structurizr/dsl/SoftwareSystemParserTests.java
+++ b/src/test/java/com/structurizr/dsl/SoftwareSystemParserTests.java
@@ -1,5 +1,6 @@
 package com.structurizr.dsl;
 
+import com.structurizr.model.Enterprise;
 import com.structurizr.model.Location;
 import com.structurizr.model.SoftwareSystem;
 import org.junit.jupiter.api.Test;
@@ -67,6 +68,21 @@ class SoftwareSystemParserTests extends AbstractTests {
         assertNotNull(softwareSystem);
         assertEquals("", softwareSystem.getDescription());
         assertEquals(Location.Internal, softwareSystem.getLocation());
+        assertEquals("Element,Software System", softwareSystem.getTags());
+    }
+
+    @Test
+    void test_parse_CreatesAnExternalSoftwareSystem() {
+        ModelDslContext context = context();
+        context.getWorkspace().getModel().setEnterprise(new Enterprise("Example Enterprise"));
+
+        parser.parse(context, tokens("softwareSystem", "Name"));
+
+        assertEquals(1, model.getElements().size());
+        SoftwareSystem softwareSystem = model.getSoftwareSystemWithName("Name");
+        assertNotNull(softwareSystem);
+        assertEquals("", softwareSystem.getDescription());
+        assertEquals(Location.External, softwareSystem.getLocation());
         assertEquals("Element,Software System", softwareSystem.getTags());
     }
 


### PR DESCRIPTION
Fix for https://github.com/structurizr/java-extensions/issues/40 . This fix will only mark a software system or person as external when an enterprise is used inside the dsl. Otherwise it will use the existing behaviour.