### PR TITLE
Changed example from "local" to "hierarchical"

### DIFF
--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -159,7 +159,7 @@ The `!identifiers` keyword allows you to specify that element identifiers should
 ```
 workspace {
 
-    !identifiers local
+    !identifiers hierarchical
 
     model {
         softwareSystem1 = softwareSystem "Software System 1" {


### PR DESCRIPTION
Using the example "!identifiers local" produces error "Expected: !identifiers <flat|hierarchical> at line 6: !identifiers local".

Changing it to "!identifiers hierarchical" works.