### PR TITLE
Document ref

### DIFF
--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -19,6 +19,7 @@ __Please note that what you see here may not be available in the Structurizr CLI
         - [!adrs](#architecture-decision-records-adrs)
         - [model](#model)
             - [impliedRelationships](#impliedRelationships)
+            - [ref](#ref)
             - [enterprise](#enterprise)
             - [group](#group)
             - [person](#person)
@@ -589,6 +590,24 @@ Permitted children:
 - [properties](#properties)
 - [perspectives](#perspectives)
 - [-> (relationship)](#relationship)
+
+### ref
+
+The `ref` keyword retrieves an already defined element by its canonical name.
+
+```structurizr
+ref = ref <canonical name> {
+    ...
+}
+```
+
+For example:
+
+```structurizr
+person = ref "Person://User"
+```
+
+For permitted children consult the documentation for the model element that is being referenced.
 
 ### relationship
 


### PR DESCRIPTION
Added some notes on `ref` which seemed to be missing from the docs although one could stumble across it while reading through some examples and the parser code. 

Let me know if there is a misunderstanding in the provided doc edits.

P.S.: Basically stumbled across it while attempting to draft the Rouge lexer (https://github.com/rouge-ruby/rouge/pull/1723/files) such that I can finally have some highlighting on GitHub and Gitlab. 😝