### PR TITLE
Enable JaCoCo plugin to track test coverage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java'
+apply plugin: 'jacoco'
 apply plugin: 'maven-publish'
 apply plugin: 'maven'
 apply plugin: 'signing'
@@ -26,8 +27,17 @@ description = 'Structurizr DSL'
 group = 'com.structurizr'
 version = '1.12.0'
 
+jacoco {
+  toolVersion = "0.8.4"
+}
+
 test {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    dependsOn test
 }
 
 jar {


### PR DESCRIPTION
Not sure if this is already configured somewhere, but I tend to go for tests and coverage reports first when looking into a project so I had to make these changes to get some semblance of test coverage.

Feel free to ignore if you already obtain visibility over coverage in some other manner.