### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Here are some tools designed to support the Structurizr DSL.
 * [Structurizr Lite](https://structurizr.com/help/lite) (web-based rendering tool)
 * [c4viz](https://github.com/pmorch/c4viz) (web-based rendering tool)
 * [Structurizr CLI](https://github.com/structurizr/cli) (command line utilities)
-* [VS Code extension]](https://marketplace.visualstudio.com/items?itemName=systemticks.c4-dsl-extension) (syntax highlighting and diagram previews; please note that there are some known issues with the syntax highlighting - see [Divergences](https://gitlab.com/systemticks/c4-grammar/-/tree/master/extension#divergences) for more details, and [Examples](https://gitlab.com/systemticks/c4-grammar/-/tree/master/workspace) for examples that work correctly with the extension)
+* [VS Code extension](https://marketplace.visualstudio.com/items?itemName=systemticks.c4-dsl-extension) (syntax highlighting and diagram previews; please note that there are some known issues with the syntax highlighting - see [Divergences](https://gitlab.com/systemticks/c4-grammar/-/tree/master/extension#divergences) for more details, and [Examples](https://gitlab.com/systemticks/c4-grammar/-/tree/master/workspace) for examples that work correctly with the extension)
 * [VS Code extension](https://marketplace.visualstudio.com/items?itemName=ciarant.vscode-structurizr) (syntax highlighting)
 
 ## Examples


### PR DESCRIPTION
Fix a small typo under Tooling support

Note: I just made this edit via the GitHub UI so I'm not sure why it appears to have changed the line ending at the end of the file as well.