### PR TITLE
Remove e.printStackTrace()

### DIFF
--- a/src/main/java/com/structurizr/dsl/InlineScriptDslContext.java
+++ b/src/main/java/com/structurizr/dsl/InlineScriptDslContext.java
@@ -40,8 +40,7 @@ class InlineScriptDslContext extends ScriptDslContext {
 
             run(this, fileExtension, lines);
         } catch (Exception e) {
-            e.printStackTrace();
-            throw new RuntimeException("Error running inline script, caused by " + e.getClass().getName() + ": " + e.getMessage());
+            throw new ("Error running inline script, caused by " + e.getClass().getName() + ": " + e.getMessage());
         }
     }
 


### PR DESCRIPTION
I guess we could use a logger if we really want to print the stacktrace? Alternatively, we could add `e` as the cause of the `RuntimeException`?