### PR TITLE
Fix minor typo in docs/language-reference

### DIFF
--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -813,7 +813,7 @@ technology "Technology"
 `instances` is used to set the number of instances of a deployment node.
 
 ```
-imstances "4"
+instances "4"
 ```
 
 ### url


### PR DESCRIPTION
Hi,
thanks for your work on structurizr - it's really awesome.

This PR fixes a minor typo in the language-reference.